### PR TITLE
[#3] [#6] 마이페이지 & 게시글 작성페이지 리펙토링

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,7 @@
 		"@typescript-eslint/triple-slash-reference": "off",
 		"react/react-in-jsx-scope": "off",
 		"no-var": "error",
-		"no-unused-vars": ["error",{ "args": "none" }],
+		"no-unused-vars": ["error", { "args": "none" }],
 		"eqeqeq": "error",
 		"no-console": "off"
 	}

--- a/src/core/apis/common.ts
+++ b/src/core/apis/common.ts
@@ -16,5 +16,6 @@ export const API_PATH = {
 		postlist: '/api/posts',
 		post: '/api/post',
 		like: '/api/like',
+		mypost: '/api/mypost',
 	},
 } as const;

--- a/src/core/apis/post.ts
+++ b/src/core/apis/post.ts
@@ -8,7 +8,7 @@ import {
 	DeletePostResponseDto,
 } from '../../types/api';
 
-export const getPostList = async (category: string, area: string, pageParam: number) => {
+export const fetchPostList = async (category: string, area: string, pageParam: number) => {
 	const {
 		post: { postlist },
 	} = API_PATH;
@@ -109,6 +109,19 @@ export const deletePost = async (postId: string) => {
 	const { payload } = await requester<DeletePostResponseDto>({
 		method: httpMethod.DELETE,
 		url: `${post}/${postId}`,
+	});
+
+	return payload;
+};
+
+export const fetchMyPostList = async (filter: string, pageParam: number) => {
+	const {
+		post: { mypost },
+	} = API_PATH;
+
+	const { payload } = await requester<PostListResponseDto>({
+		method: httpMethod.GET,
+		url: `${mypost}?filter=${filter}&page=${pageParam}&size=6`,
 	});
 
 	return payload;

--- a/src/hooks/useAddPost.ts
+++ b/src/hooks/useAddPost.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { queryKeys } from '../constants/queryKeys';
+import { postNewPost, editPost } from '../core/apis/post';
+
+type Props = {
+	isEditingMode: boolean;
+	postValue: object;
+	postId: string | undefined;
+};
+
+const useAddPost = ({ isEditingMode, postValue, postId }: Props) => {
+	const navigate = useNavigate();
+	const queryClient = useQueryClient();
+
+	const addPost = async () => {
+		if (isEditingMode) {
+			try {
+				const data = await editPost(postValue, postId!);
+				alert('게시글이 수정되었습니다');
+				return data;
+			} catch (err) {
+				console.error(err);
+			}
+		} else {
+			try {
+				const data = await postNewPost(postValue);
+				alert('게시글이 등록되었습니다');
+				return data;
+			} catch (err) {
+				console.error(err);
+			}
+		}
+	};
+
+	const { mutate: onAdd } = useMutation(addPost, {
+		onSuccess: () => {
+			queryClient.invalidateQueries([queryKeys.postList], { refetchType: 'all' });
+			queryClient.invalidateQueries([queryKeys.postDetail], { refetchType: 'all' });
+			if (isEditingMode) {
+				navigate(`/post/${postId}`);
+			} else {
+				navigate(`/home`);
+			}
+		},
+	});
+
+	return onAdd;
+};
+
+export default useAddPost;

--- a/src/hooks/useMyPostList.ts
+++ b/src/hooks/useMyPostList.ts
@@ -1,0 +1,24 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { queryKeys } from '../constants/queryKeys';
+import { fetchMyPostList } from '../core/apis/post';
+
+const useMyPostList = (filter: string) => {
+	const getMyPostList = async (pageParam: number) => {
+		const payload = await fetchMyPostList(filter, pageParam);
+		let data = payload.list.content;
+		let last = payload.pageable.last;
+		return { data, last, nextPage: pageParam + 1 };
+	};
+
+	const {
+		data: myPostListData,
+		fetchNextPage,
+		isFetchingNextPage,
+	} = useInfiniteQuery([queryKeys.myPostList, filter], ({ pageParam = 0 }) => getMyPostList(pageParam), {
+		getNextPageParam: (LastPage) => (!LastPage.last ? LastPage.nextPage : undefined),
+	});
+
+	return { myPostListData, fetchNextPage, isFetchingNextPage };
+};
+
+export default useMyPostList;

--- a/src/hooks/usePostDetail.ts
+++ b/src/hooks/usePostDetail.ts
@@ -14,7 +14,7 @@ const usePostDetail = (postId: string) => {
 		return res;
 	};
 
-	const postInfo = useQuery([queryKeys.postDetail], extractPostDetail, {
+	const postInfo = useQuery([queryKeys.postDetail, postId], extractPostDetail, {
 		refetchOnWindowFocus: false,
 	}).data;
 

--- a/src/hooks/usePostList.ts
+++ b/src/hooks/usePostList.ts
@@ -1,4 +1,4 @@
-import { getPostList, extractPostListByKeyword } from '../core/apis/post';
+import { fetchPostList, extractPostListByKeyword } from '../core/apis/post';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { queryKeys } from '../constants/queryKeys';
 
@@ -15,7 +15,7 @@ const usePostList = (searchKeyword: string, postFilterObj: Props) => {
 			const last = payload.pageable.last;
 			return { data, nextPage: pageParam + 1, last };
 		} else {
-			const res = await getPostList(postFilterObj.category, postFilterObj.area, pageParam);
+			const res = await fetchPostList(postFilterObj.category, postFilterObj.area, pageParam);
 			const data = res.list.content;
 			const last = res.pageable.last;
 			return { data, nextPage: pageParam + 1, last };

--- a/src/pages/AddPost/index.tsx
+++ b/src/pages/AddPost/index.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState, ComponentProps } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import Layout from '../../components/layout';
+import DropDown from '../../components/shared/DropDown';
+import { dropDownTable } from '../../constants/dropDown';
+import useAddPost from '../../hooks/useAddPost';
+import { PostAddWrap } from './styled';
+
+const AddPost = () => {
+	const location = useLocation();
+	const params = useParams();
+	const editPostValue = location.state;
+	const postId = params.postId;
+	const [isEditingMode, setIsEditingMode] = useState(false);
+	const [postValue, setPostValue] = useState({
+		title: '',
+		price: 0,
+		area: '',
+		category: '',
+		content: '',
+		imageUrl: '',
+	});
+	const { title, price, content } = postValue;
+	const onAdd = useAddPost({ isEditingMode, postValue, postId });
+	const [validatePost, setValidatePost] = useState(false);
+
+	const onChangeInput: ComponentProps<'input'>['onChange'] = (e) => {
+		setPostValue({
+			...postValue,
+			[e.target.name]: e.target.value,
+		});
+	};
+
+	const onChangeTextArea: ComponentProps<'textarea'>['onChange'] = (e) => {
+		setPostValue({
+			...postValue,
+			[e.target.name]: e.target.value,
+		});
+	};
+
+	useEffect(() => {
+		if (editPostValue) {
+			setPostValue(editPostValue);
+			setIsEditingMode(true);
+		}
+	}, []);
+
+	useEffect(() => {
+		if (
+			postValue.area !== '' &&
+			postValue.category !== '' &&
+			postValue.content !== '' &&
+			postValue.title !== '' &&
+			postValue.price !== 0
+		) {
+			setValidatePost(true);
+		}
+	}, [postValue]);
+
+	const handleDropdownFilterChange = (value: string, changeTarget: string) => {
+		setPostValue({ ...postValue, [changeTarget]: value });
+	};
+
+	return (
+		<Layout>
+			<PostAddWrap>
+				<h2>게시글 {editPostValue ? '수정' : '작성'}</h2>
+				<div>
+					<p>제목</p>
+					<input type="text" name="title" placeholder="제목을 입력해주세요" onChange={onChangeInput} value={title} />
+				</div>
+				<div>
+					<p>지역</p>
+					<DropDown dropdownTarget="area" options={dropDownTable.AreaOptions} onDropdownChange={handleDropdownFilterChange} />
+				</div>
+				<div>
+					<p>카테고리</p>
+					<DropDown
+						dropdownTarget="category"
+						options={dropDownTable.CategoryOptions}
+						onDropdownChange={handleDropdownFilterChange}
+					/>
+				</div>
+				<div>
+					<p>가격</p>
+					<input type="number" name="price" placeholder="가격을 입력해주세요" onChange={onChangeInput} value={price} />
+				</div>
+				<div className="contentDiv">
+					<p>내용</p>
+					<textarea name="content" placeholder="내용을 입력해주세요" onChange={onChangeTextArea} value={content} />
+				</div>
+				<button
+					onClick={() => {
+						const result = window.confirm('등록하시겠습니까?');
+						if (result) {
+							onAdd();
+						}
+					}}
+					disabled={!validatePost}
+				>
+					게시글 {editPostValue ? '수정' : '작성'}하기
+				</button>
+			</PostAddWrap>
+		</Layout>
+	);
+};
+
+export default AddPost;

--- a/src/pages/AddPost/styled.ts
+++ b/src/pages/AddPost/styled.ts
@@ -1,0 +1,43 @@
+import styled from 'styled-components';
+
+export const PostAddWrap = styled.div`
+	height: calc(100vh - 7rem);
+	width: 40rem;
+	display: flex;
+	flex-direction: column;
+	margin: 0 auto;
+	align-items: flex-start;
+	justify-content: space-evenly;
+	h2 {
+		font-size: 1.5rem;
+		font-weight: 700;
+	}
+
+	div {
+		width: 100%;
+		display: flex;
+		padding: 0 1rem;
+		p {
+			margin-right: 1rem;
+		}
+		input {
+			width: 60%;
+		}
+	}
+
+	.contentDiv {
+		textarea {
+			width: 35rem;
+			height: 8rem;
+		}
+	}
+	button {
+		width: 20rem;
+		margin-left: 10rem;
+		font-size: 1.3rem;
+		padding: 0.3rem;
+		border-radius: 0.5rem;
+		border: none;
+		background-color: #ffecd7;
+	}
+`;

--- a/src/pages/Mypage/index.tsx
+++ b/src/pages/Mypage/index.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { logout } from '../../core/apis/auth';
+import Layout from '../../components/layout';
+import { MypageWrap } from './styled';
+import { IoIosPaper } from 'react-icons/io';
+import { AiFillHeart } from 'react-icons/ai';
+import { FaCarrot } from 'react-icons/fa';
+
+const Mypage = () => {
+	const nickName = JSON.parse(localStorage.getItem('userInfo')!).username;
+	const [filter, setFilter] = useState('sale');
+	const navigate = useNavigate();
+
+	const handleLogout = async () => {
+		await logout;
+		localStorage.clear();
+		alert('로그아웃 되었습니다.');
+		navigate('/');
+	};
+
+	useEffect(() => {
+		console.log(filter);
+	}, [filter]);
+
+	return (
+		<Layout>
+			<MypageWrap>
+				<p className="pageTitle">나의 당근</p>
+				<div className="userinfoDiv">
+					<FaCarrot />
+					<p>{nickName} 님</p>
+					<button onClick={handleLogout}>로그아웃</button>
+				</div>
+				<div className="filterDiv">
+					<button
+						onClick={() => {
+							setFilter('sale');
+						}}
+					>
+						<IoIosPaper />
+						<p>판매내역</p>
+					</button>
+					<button
+						onClick={() => {
+							setFilter('interest');
+						}}
+					>
+						<AiFillHeart />
+						<p>관심목록</p>
+					</button>
+				</div>
+				<div className="contentDiv"></div>
+			</MypageWrap>
+		</Layout>
+	);
+};
+
+export default Mypage;

--- a/src/pages/Mypage/styled.ts
+++ b/src/pages/Mypage/styled.ts
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+
+export const MypageWrap = styled.div`
+	display: flex;
+	flex-direction: column;
+	height: calc(100vh - 7rem);
+	.pageTitle {
+		margin: 1rem 2.7rem;
+		font-size: 1.3rem;
+		font-weight: 700;
+	}
+	.userinfoDiv {
+		height: 7rem;
+		padding: 3.7rem;
+		display: flex;
+		align-items: center;
+		justify-content: flex-start;
+		svg {
+			width: 5rem;
+			height: 5rem;
+			padding: 0.3rem;
+			margin-right: 3rem;
+			border-radius: 5rem;
+			border: 2px solid #e78111;
+			color: #e78111;
+		}
+		p {
+			margin-right: 1rem;
+			font-size: 1.3rem;
+			font-weight: 600;
+		}
+		button {
+			padding: 0.5rem;
+			border: none;
+			border-radius: 0.5rem;
+			background: #ffecd7;
+		}
+	}
+	.filterDiv {
+		height: 5rem;
+		display: flex;
+		padding: 1rem auto;
+		justify-content: space-evenly;
+		align-items: center;
+		border-bottom: 0.1rem solid #ffecd7;
+		button {
+			border: none;
+			background-color: transparent;
+			cursor: pointer;
+			svg {
+				width: 3rem;
+				height: 3rem;
+				padding: 0.3rem;
+				border-radius: 50%;
+				color: #e78111;
+				background-color: #ffecd7;
+			}
+		}
+	}
+	.contentDiv {
+		overflow-y: auto;
+	}
+`;


### PR DESCRIPTION
## 해결한 이슈

- #3 #6 

<br />

## 해결 방법

`Custom Hook을 사용한 로직과 UI 분리`

 + KISS(Keep It Simple, Stupid)
   - 각 모듈들은 간단하고, 단순하게 만들라는 의미로서 여러 기능을 포함시키면서 복잡하게 만들면 유지보수가 힘들어지기에, 하나의 기능만 수행하도록 하라는 의미에 따라 로직과 UI를 구분

<br />

## 캡처 첨부

`마이페이지`

<img width="610" alt="스크린샷 2022-12-16 오전 2 56 39" src="https://user-images.githubusercontent.com/108744804/208255769-db5b9375-f8e2-48f9-a920-c7eb1cc8c8d9.png">

`게시글 작성 페이지`

<img width="779" alt="스크린샷 2022-12-18 오전 3 17 52" src="https://user-images.githubusercontent.com/108744804/208255850-8b5fffe6-edd1-448a-8eb4-9864f6313263.png">


<br />

## 추가적인 태스크

- 고려해봐야할 문제
   - 공통으로 사용되는 로직이 아닌경우에도, hook을 사용해서 분리하는게 맞는지 여부   

<br />
<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
