### PR TITLE
[#12] 게시물 무한스크롤 기능 에러 해결

### DIFF
--- a/src/components/feature/PostListItem/index.tsx
+++ b/src/components/feature/PostListItem/index.tsx
@@ -8,7 +8,6 @@ const PostListItem = ({ post }: PostDetailResponseDto) => {
 		<PostListItemWrap>
 			<div className="postDiv">
 				<div className="imgDiv">
-					{/* {post.imageUrl ? <img src={post.imageUrl} alt="postImg" /> : <img src="/image/logo.png" alt="alternativeImg" />} */}
 					<img src="/image/logo.png" alt="postimage" />
 				</div>
 				<div className="infoDiv">

--- a/src/components/feature/PostListItem/styled.ts
+++ b/src/components/feature/PostListItem/styled.ts
@@ -31,6 +31,9 @@ export const PostListItemWrap = styled.div`
 	}
 
 	.likeDiv {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
 		svg {
 			width: 1rem;
 			height: 1rem;

--- a/src/components/layout/Footer/index.tsx
+++ b/src/components/layout/Footer/index.tsx
@@ -21,13 +21,7 @@ const Footer = () => {
 				<p>홈</p>
 			</div>
 			<div className="buttonDiv">
-				<button
-					onClick={() => {
-						navigate('/mychatroom');
-					}}
-				>
-					{currentPage === '/mychatroom' ? <HiChatAlt2 /> : <HiOutlineChatAlt2 />}
-				</button>
+				<button>{currentPage === '/mychatroom' ? <HiChatAlt2 /> : <HiOutlineChatAlt2 />}</button>
 				<p>채팅</p>
 			</div>
 			<div className="buttonDiv">

--- a/src/core/apis/requester.ts
+++ b/src/core/apis/requester.ts
@@ -16,7 +16,7 @@ export default async function requester<Payload>(option: AxiosRequestConfig) {
 		accessToken
 			? {
 					headers: {
-						Authorization: `Bearer ${accessToken}`,
+						Authorization: `${accessToken}`,
 						'content-type': 'application/json;charset=UTF-8',
 						accept: 'application/json,',
 					},

--- a/src/hooks/useAddPost.ts
+++ b/src/hooks/useAddPost.ts
@@ -15,21 +15,13 @@ const useAddPost = ({ isEditingMode, postValue, postId }: Props) => {
 
 	const addPost = async () => {
 		if (isEditingMode) {
-			try {
-				const data = await editPost(postValue, postId!);
-				alert('게시글이 수정되었습니다');
-				return data;
-			} catch (err) {
-				console.error(err);
-			}
+			const data = await editPost(postValue, postId!);
+			alert('게시글이 수정되었습니다');
+			return data;
 		} else {
-			try {
-				const data = await postNewPost(postValue);
-				alert('게시글이 등록되었습니다');
-				return data;
-			} catch (err) {
-				console.error(err);
-			}
+			const data = await postNewPost(postValue);
+			alert('게시글이 등록되었습니다');
+			return data;
 		}
 	};
 

--- a/src/hooks/useMyPostList.ts
+++ b/src/hooks/useMyPostList.ts
@@ -5,8 +5,8 @@ import { fetchMyPostList } from '../core/apis/post';
 const useMyPostList = (filter: string) => {
 	const getMyPostList = async (pageParam: number) => {
 		const payload = await fetchMyPostList(filter, pageParam);
-		let data = payload.list.content;
-		let last = payload.pageable.last;
+		const data = payload.list.content;
+		const last = payload.list.last;
 		return { data, last, nextPage: pageParam + 1 };
 	};
 
@@ -15,7 +15,7 @@ const useMyPostList = (filter: string) => {
 		fetchNextPage,
 		isFetchingNextPage,
 	} = useInfiniteQuery([queryKeys.myPostList, filter], ({ pageParam = 0 }) => getMyPostList(pageParam), {
-		getNextPageParam: (LastPage) => (!LastPage.last ? LastPage.nextPage : undefined),
+		getNextPageParam: (myPostListData) => (!myPostListData.last ? myPostListData.nextPage : undefined),
 	});
 
 	return { myPostListData, fetchNextPage, isFetchingNextPage };

--- a/src/hooks/useMyPostList.ts
+++ b/src/hooks/useMyPostList.ts
@@ -1,6 +1,7 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { queryKeys } from '../constants/queryKeys';
-import { fetchMyPostList } from '../core/apis/post';
+
+import { queryKeys } from '@src/constants/queryKeys';
+import { fetchMyPostList } from '@src/core/apis/post';
 
 const useMyPostList = (filter: string) => {
 	const getMyPostList = async (pageParam: number) => {

--- a/src/hooks/usePostList.ts
+++ b/src/hooks/usePostList.ts
@@ -9,16 +9,16 @@ type Props = {
 
 const usePostList = (searchKeyword: string, postFilterObj: Props) => {
 	const getPosts = async (pageParam: number) => {
-		if (searchKeyword !== '') {
+		if (searchKeyword === '') {
+			const payload = await fetchPostList(postFilterObj.category, postFilterObj.area, pageParam);
+			const data = payload.list.content;
+			const last = payload.list.last;
+			return { data, last, nextPage: pageParam + 1 };
+		} else {
 			const payload = await extractPostListByKeyword(searchKeyword, pageParam);
 			const data = payload.list.content;
-			const last = payload.pageable.last;
-			return { data, nextPage: pageParam + 1, last };
-		} else {
-			const res = await fetchPostList(postFilterObj.category, postFilterObj.area, pageParam);
-			const data = res.list.content;
-			const last = res.pageable.last;
-			return { data, nextPage: pageParam + 1, last };
+			const last = payload.list.last;
+			return { data, last, nextPage: pageParam + 1 };
 		}
 	};
 
@@ -27,10 +27,10 @@ const usePostList = (searchKeyword: string, postFilterObj: Props) => {
 		fetchNextPage,
 		isFetchingNextPage,
 	} = useInfiniteQuery(
-		[queryKeys.postList, postFilterObj.category, postFilterObj.area],
+		[queryKeys.postList, postFilterObj.area, postFilterObj.category, searchKeyword],
 		({ pageParam = 0 }) => getPosts(pageParam),
 		{
-			getNextPageParam: (lastPage) => (!lastPage.last ? lastPage.nextPage : undefined),
+			getNextPageParam: (postListData) => (!postListData.last ? postListData.nextPage : undefined),
 		},
 	);
 

--- a/src/hooks/usePostList.ts
+++ b/src/hooks/usePostList.ts
@@ -1,13 +1,14 @@
-import { fetchPostList, extractPostListByKeyword } from '../core/apis/post';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { queryKeys } from '../constants/queryKeys';
+
+import { queryKeys } from '@src/constants/queryKeys';
+import { fetchPostList, extractPostListByKeyword } from '@src/core/apis/post';
 
 type Props = {
 	area: string;
 	category: string;
 };
 
-const usePostList = (searchKeyword: string, postFilterObj: Props) => {
+const usePostList = (postFilterObj: Props, searchKeyword: string) => {
 	const getPosts = async (pageParam: number) => {
 		if (searchKeyword === '') {
 			const payload = await fetchPostList(postFilterObj.category, postFilterObj.area, pageParam);
@@ -26,15 +27,16 @@ const usePostList = (searchKeyword: string, postFilterObj: Props) => {
 		data: postListData,
 		fetchNextPage,
 		isFetchingNextPage,
+		hasNextPage,
 	} = useInfiniteQuery(
-		[queryKeys.postList, postFilterObj.area, postFilterObj.category, searchKeyword],
+		[queryKeys.postList, postFilterObj.category, postFilterObj.area, searchKeyword],
 		({ pageParam = 0 }) => getPosts(pageParam),
 		{
 			getNextPageParam: (postListData) => (!postListData.last ? postListData.nextPage : undefined),
 		},
 	);
 
-	return { postListData, fetchNextPage, isFetchingNextPage };
+	return { postListData, fetchNextPage, isFetchingNextPage, hasNextPage };
 };
 
 export default usePostList;

--- a/src/pages/AddPost/index.tsx
+++ b/src/pages/AddPost/index.tsx
@@ -1,22 +1,32 @@
 import { useEffect, useState, ComponentProps } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import Layout from '../../components/layout';
 import DropDown from '../../components/shared/DropDown';
 import { dropDownTable } from '../../constants/dropDown';
 import useAddPost from '../../hooks/useAddPost';
 import { PostAddWrap } from './styled';
 
+type Props = {
+	title: string;
+	price: number;
+	area: string;
+	category: string;
+	content: string;
+	imageUrl: string;
+};
+
 const AddPost = () => {
+	const navigate = useNavigate();
 	const location = useLocation();
 	const params = useParams();
-	const editPostValue = location.state;
+	const editPostValue: Props = location.state;
 	const postId = params.postId;
 	const [isEditingMode, setIsEditingMode] = useState(false);
 	const [postValue, setPostValue] = useState({
 		title: '',
 		price: 0,
-		area: '',
-		category: '',
+		area: 'ALL',
+		category: 'ALL',
 		content: '',
 		imageUrl: '',
 	});
@@ -47,8 +57,8 @@ const AddPost = () => {
 
 	useEffect(() => {
 		if (
-			postValue.area !== '' &&
-			postValue.category !== '' &&
+			postValue.area !== 'ALL' &&
+			postValue.category !== 'ALL' &&
 			postValue.content !== '' &&
 			postValue.title !== '' &&
 			postValue.price !== 0
@@ -94,6 +104,8 @@ const AddPost = () => {
 						const result = window.confirm('등록하시겠습니까?');
 						if (result) {
 							onAdd();
+						} else {
+							navigate(-1);
 						}
 					}}
 					disabled={!validatePost}

--- a/src/pages/Mypage/index.tsx
+++ b/src/pages/Mypage/index.tsx
@@ -58,26 +58,27 @@ const Mypage = () => {
 						<p>관심목록</p>
 					</button>
 				</div>
-				{myPostListData &&
-					myPostListData.pages.map((page: any, idx: number) => {
-						return (
-							<React.Fragment key={idx}>
-								{page.data.map((post: PostDetailData) => (
-									<div
-										className="contentDiv"
-										key={post.id}
-										style={{ cursor: 'pointer' }}
-										onClick={() => {
-											navigate(`/post/${post.id}`);
-										}}
-									>
-										<PostListItem post={post} />
-									</div>
-								))}
-							</React.Fragment>
-						);
-					})}
-				{isFetchingNextPage ? <div>로딩중...</div> : <div ref={ref} />}
+				<div className="contentDiv">
+					{myPostListData &&
+						myPostListData.pages.map((page: any, idx: number) => {
+							return (
+								<React.Fragment key={idx}>
+									{page.data.map((post: PostDetailData) => (
+										<div
+											key={post.id}
+											style={{ cursor: 'pointer' }}
+											onClick={() => {
+												navigate(`/post/${post.id}`);
+											}}
+										>
+											<PostListItem post={post} />
+										</div>
+									))}
+								</React.Fragment>
+							);
+						})}
+					{isFetchingNextPage ? <div>로딩중...</div> : <div ref={ref} />}
+				</div>
 			</MypageWrap>
 		</Layout>
 	);

--- a/src/pages/Mypage/index.tsx
+++ b/src/pages/Mypage/index.tsx
@@ -1,15 +1,18 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useInView } from 'react-intersection-observer';
-import { logout } from '../../core/apis/auth';
-import Layout from '../../components/layout';
-import { MypageWrap } from './styled';
-import { IoIosPaper } from 'react-icons/io';
+
 import { AiFillHeart } from 'react-icons/ai';
 import { FaCarrot } from 'react-icons/fa';
-import useMyPostList from '../../hooks/useMyPostList';
-import { PostDetailData } from '../../types/api';
-import PostListItem from '../../components/feature/PostListItem';
+import { IoIosPaper } from 'react-icons/io';
+import { useInView } from 'react-intersection-observer';
+
+import { Layout, PostListItem } from '@src/components';
+import SkeletonPostList from '@src/components/feature/Skeleton/SkeletonPostList';
+import { logout } from '@src/core/apis/auth';
+import useMyPostList from '@src/hooks/useMyPostList';
+import { PostDetailData } from '@src/types/api';
+
+import { MypageWrap } from './styled';
 
 const Mypage = () => {
 	const navigate = useNavigate();
@@ -77,7 +80,7 @@ const Mypage = () => {
 								</React.Fragment>
 							);
 						})}
-					{isFetchingNextPage ? <div>로딩중...</div> : <div ref={ref} />}
+					{isFetchingNextPage ? <SkeletonPostList /> : <div className="filterDiv" ref={ref} />}
 				</div>
 			</MypageWrap>
 		</Layout>

--- a/src/pages/Mypage/styled.ts
+++ b/src/pages/Mypage/styled.ts
@@ -59,5 +59,8 @@ export const MypageWrap = styled.div`
 	}
 	.contentDiv {
 		overflow-y: auto;
+		.filterDiv {
+			height: 0.1rem;
+		}
 	}
 `;

--- a/src/pages/PostDetail/index.tsx
+++ b/src/pages/PostDetail/index.tsx
@@ -24,7 +24,7 @@ const PostDetail = () => {
 							</button>
 							{postInfo.nickname === loginUserName && (
 								<div className="buttonDiv">
-									<button onClick={() => navigate(`/post/${params.postId}`)}>
+									<button onClick={() => navigate(`/post/${params.postId}/edit`, { state: postInfo })}>
 										<AiOutlineEdit />
 									</button>
 									<button onClick={() => onDelete()}>

--- a/src/pages/PostDetail/styled.ts
+++ b/src/pages/PostDetail/styled.ts
@@ -47,7 +47,7 @@ export const PostDetailWrap = styled.div`
 			gap: 1.5rem;
 			margin: 3rem 0;
 			svg {
-				width: 5rem;
+				width: 8rem;
 				height: 5rem;
 				color: #e78111;
 				padding: 0.3rem;
@@ -56,13 +56,13 @@ export const PostDetailWrap = styled.div`
 				border: 2px solid #e78111;
 			}
 			.userInfo {
+				width: 100%;
 				p {
 					margin-bottom: 0.5rem;
 				}
 			}
 		}
 		button {
-			margin-left: 15rem;
 			background-color: transparent;
 			border: 0;
 			cursor: pointer;

--- a/src/pages/PostList/index.tsx
+++ b/src/pages/PostList/index.tsx
@@ -1,15 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { useInView } from 'react-intersection-observer';
-import Layout from '../../components/layout';
-import PostListItem from '../../components/feature/PostListItem';
-import DropDown from '../../components/shared/DropDown';
-import SearchInput from '../../components/shared/SearchInput';
-import { dropDownTable } from '../../constants/dropDown';
-import usePostList from '../../hooks/usePostList';
-import { PostListWrap } from './styled';
+
 import { FiPlusCircle } from 'react-icons/fi';
-import { PostDetailData } from '../../types/api';
+import { useInView } from 'react-intersection-observer';
+
+import { Layout, PostListItem, DropDown, SearchInput } from '@src/components';
+import SkeletonPostList from '@src/components/feature/Skeleton/SkeletonPostList';
+import { dropDownTable } from '@src/constants/dropDown';
+import usePostList from '@src/hooks/usePostList';
+import { PostDetailData } from '@src/types/api';
+
+import { PostListWrap } from './styled';
 
 const PostList = () => {
 	const navigate = useNavigate();
@@ -19,10 +20,10 @@ const PostList = () => {
 		area: 'ALL',
 		category: 'ALL',
 	});
-	const { postListData, fetchNextPage, isFetchingNextPage } = usePostList(searchKeyword, postFilterObj);
+	const { postListData, fetchNextPage, isFetchingNextPage, hasNextPage } = usePostList(postFilterObj, searchKeyword);
 
 	useEffect(() => {
-		if (inView) {
+		if (inView && hasNextPage) {
 			fetchNextPage();
 		}
 	}, [inView]);
@@ -68,8 +69,8 @@ const PostList = () => {
 								</React.Fragment>
 							);
 						})}
+					{isFetchingNextPage ? <SkeletonPostList /> : <div className="filterDiv" ref={ref} />}
 				</div>
-				{isFetchingNextPage ? <div>로딩중...</div> : <div ref={ref} />}
 				<div className="postAddDiv">
 					<Link to="/addpost">
 						<FiPlusCircle />

--- a/src/pages/PostList/index.tsx
+++ b/src/pages/PostList/index.tsx
@@ -49,25 +49,26 @@ const PostList = () => {
 					</div>
 					<SearchInput onSearchByKeyword={handleSearchByKeyword} />
 				</div>
-				{postListData &&
-					postListData.pages.map((page: any, idx: number) => {
-						return (
-							<React.Fragment key={idx}>
-								{page.data.map((post: PostDetailData) => (
-									<div
-										className="listDiv"
-										key={post.id}
-										style={{ cursor: 'pointer' }}
-										onClick={() => {
-											navigate(`/post/${post.id}`);
-										}}
-									>
-										<PostListItem post={post} />
-									</div>
-								))}
-							</React.Fragment>
-						);
-					})}
+				<div className="listDiv">
+					{postListData &&
+						postListData.pages.map((page: any, idx: number) => {
+							return (
+								<React.Fragment key={idx}>
+									{page.data.map((post: PostDetailData) => (
+										<div
+											key={post.id}
+											style={{ cursor: 'pointer' }}
+											onClick={() => {
+												navigate(`/post/${post.id}`);
+											}}
+										>
+											<PostListItem post={post} />
+										</div>
+									))}
+								</React.Fragment>
+							);
+						})}
+				</div>
 				{isFetchingNextPage ? <div>로딩중...</div> : <div ref={ref} />}
 				<div className="postAddDiv">
 					<Link to="/addpost">

--- a/src/pages/PostList/styled.ts
+++ b/src/pages/PostList/styled.ts
@@ -35,6 +35,9 @@ export const PostListWrap = styled.div`
 		position: relative;
 		top: 7rem;
 		overflow-y: auto;
+		.filterDiv {
+			height: 0.1rem;
+		}
 	}
 	.postAddDiv {
 		position: fixed;

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -11,7 +11,7 @@ const SignUp = () => {
 		onSubmit: async (values: object) => {
 			await signup(values);
 			alert('회원가입 완료! 로그인 페이지로 이동합니다.');
-			navigate('/singin');
+			navigate('/signin');
 		},
 		validateSign,
 	});

--- a/src/router/routePath.ts
+++ b/src/router/routePath.ts
@@ -6,8 +6,6 @@ export const ROUTE_PATH = {
 	MYPAGE: '/mypage',
 	ADDPOST: '/addpost',
 	EDITPOST: '/post/:postId/edit',
-	POSTDETAIL: '/postdetail',
-	//FIXME: api 500에러 해결시 라우팅할 detailpage PATH
-	// POSTDETAIL: '/post/:postId',
+	POSTDETAIL: '/post/:postId',
 	NOT_FOUND: '*',
 } as const;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -18,7 +18,8 @@ export type PostContentDto = [
 		area: string;
 		imageUrl: string;
 		category: string;
-		after: number;
+		title: string;
+		after: string;
 		likeCount: number;
 	},
 ];
@@ -26,16 +27,31 @@ export type PostContentDto = [
 export type PostListResponseDto = {
 	list: {
 		content: PostContentDto;
+		empty: boolean;
+		first: boolean;
+		last: boolean;
+		number: 0;
+		numberOfElements: number;
+		pegeable: {
+			offset: number;
+			pageNumber: number;
+			pageSize: number;
+			paged: boolean;
+			sort: {
+				empty: boolean;
+				sorted: boolean;
+				unsorted: boolean;
+			};
+			unpaged: boolean;
+		};
+		size: number;
+		sort: {
+			empty: boolean;
+			sorted: boolean;
+			unsorted: boolean;
+		};
 	};
-	pageable: Pageable;
-};
-
-export type Pageable = {
-	totalPages: number;
-	totalElemets: string;
-	last: boolean;
-	size: number;
-	empty: boolean;
+	response: boolean;
 };
 
 export type EditPostRespnseDto = {


### PR DESCRIPTION
## 해결한 이슈

- #12 

<br />

## 해결 방법

+ `post 관련 api 요청 시 반환되는 500 error`

<img width="719" alt="스크린샷 2022-12-16 오후 9 25 52" src="https://user-images.githubusercontent.com/108744804/209474697-cd9bcb24-1f05-47c5-b4a0-2a87445f76b8.png">

- 기존 login, signup 로직에서는 문제가 없었던 상황이기에 authorization 관련 로직이 문제일 것으로 판단. 
- 백엔드 에러 로그 확인을 통해, accessToken의 인가방식 문제임을 확인하고, 네트워크 요청탭을 확인
```tsx
// 에러를 발생시킨 기존코드
 Authorization: `Bearer ${accessToken}`,
// 변경코드
Authorization: `${accessToken}`,
```
- 백에서 이미 accessToken을 보낼때 BEARER 처리를 해서 받는 로직이 구현되어있어, BEARER Bearer accessToken 으로 헤더 요청이 가서 유효한 accessToken 임에도 인가에 문제가 생긴 것

+ `무한스크롤 기능이 게시글 목록 페이지에서는 작동하지 않는 문제`

<img width="1396" alt="스크린샷 2022-12-26 오전 1 31 57" src="https://user-images.githubusercontent.com/108744804/209475566-6d241688-53b4-4740-bb22-f81d7454b089.png">

- 무한스크롤 기능이 구현된 페이지의 하단부까지 도달했음에도, api 요청이 새로 일어나거나 오류가 발생하지않고, 아무런 동작이 발생하지 않는 문제
- 동일한 로직으로 구현한 Mypage의 무한스크롤 기능은 정상적으로 동작
- useInfinityQuery의 hasNextPage, getNextPageParam는 정상적으로 작동하는 것을 확인 후 react-intersection-observer의 문제로 판단

```tsx
useEffect(() => {
		if (inView && hasNextPage) {
			fetchNextPage();
		}
	}, [inView]);
```
- useEffect로 inView가 변하고, 다음 페이지가 있을때  fetchNextPage를 하는 로직에서, 의존성 배열로 전달한 inView의 변화가 없는 문제 확인
- observer의 관찰영역인 div에 height를 주어 관찰하는 영역이 실제로 페이지에 나타나게 하여 무한스크롤이 제대로 작동하게 무한스크롤 에러 해결

```tsx 
//사용부
{isFetchingNextPage ? <SkeletonPostList /> : <div className="filterDiv" ref={ref} />}
//heigth css
.filterDiv {
	height: 0.1rem;
}
```

<br />

## 캡처 첨부

`게시물 무한스크롤 기능 시연`

https://user-images.githubusercontent.com/108744804/209476065-dc619fd6-56e9-47c8-a553-50a63f3d9db9.mov

<br />

## 추가적인 태스크

- [ ] 로딩 상황에서 사용할 스켈레톤 ui 구현

<br />
<br />

## PR Submit 이전에 확인하세요 !

`체크리스트`

- [x] Merge 하는 브랜치에 Master/Main 브랜치가 아닙니다.
